### PR TITLE
Update replaceVars to also replace unset placeholders

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -25,11 +25,5 @@ export const encodeQueryString = function(data) {
 export const replaceVars = function(text, vars = {}) {
   if (typeof text !== 'string') return text;
 
-  Object.keys(vars).forEach(key => {
-    let val = vars[key];
-
-    text = text.replace(new RegExp(`{{${key}}}`, 'g'), val);
-  });
-
-  return text;
+  return text.replace(/{{([\w.-]+)}}/g, (_, key) => vars[key] || '');
 };


### PR DESCRIPTION
I think that when {{foo}} isn't defined (yet) in wurd, it shouldn't show {{foo}}, but just a blank

This allows to add a placeholder in wurd before pushing a release, without changing the visual content